### PR TITLE
Actualizar campo de calificación en tabla últimos intentos

### DIFF
--- a/theme/spacechild/renderers/renderer-quiz.php
+++ b/theme/spacechild/renderers/renderer-quiz.php
@@ -320,7 +320,23 @@ class theme_spacechild_mod_quiz_renderer extends mod_quiz\output\renderer {
                 ) parent
                 GROUP BY quizattemptid, quiz
                 having quizattemptid = " . $attemptobj->get_attempt()->id);
-
+            
+            $flags = $DB->get_record_sql("
+                SELECT 
+                    COUNT(qa.questionid) AS cantidad, 
+                    qas.state, 
+                    quiza.quiz, 
+                    quiza.id AS quizattemptid, 
+                    quiza.userid, 
+                    qa.flagged AS flag
+                FROM mdl_quiz_attempts AS quiza
+                JOIN mdl_question_usages AS qu ON qu.id = quiza.uniqueid
+                JOIN mdl_question_attempts AS qa ON qa.questionusageid = qu.id
+                JOIN mdl_question_attempt_steps AS qas ON qas.questionattemptid = qa.id
+                LEFT JOIN mdl_question_attempt_step_data AS qasd ON qasd.attemptstepid = qas.id
+                WHERE qas.state IN ('gradedright') && flagged = 1
+                GROUP BY quiza.id, quiza.quiz, qas.state, quiza.userid
+                having quizattemptid = " . $attemptobj->get_attempt()->id);
 
             $row[] = $estadisticas->aciertos;
             $row[] = $estadisticas->fallos;
@@ -337,7 +353,7 @@ class theme_spacechild_mod_quiz_renderer extends mod_quiz\output\renderer {
             }
 
             // Ouside the if because we may be showing feedback but not grades.
-            $attemptgrade = quiz_rescale_grade($attemptobj->get_sum_marks(), $quiz, false);
+            $attemptgrade = quiz_rescale_grade($attemptobj->get_sum_marks() - $flags->cantidad, $quiz, false);
 
             if ($viewobj->gradecolumn) {
                 if (


### PR DESCRIPTION
## Descripción

- Se soluciono el error en el campo de **calificación** en la tabla **últimos intentos**.

## Resumen de los cambios

- Se hizo una consulta SQL con el fin de capturar la cantidad de banderas que tiene una pregunta en un determinado cuestionario.
- Se hizo un cálculo nuevo para mostrar la nota real.

## Checklist

- [x] Reemplazo de "**nota arriesgado**" por "**nota real**".

## Screensshots

![image](https://github.com/gerpollo2000/dfp/assets/116986434/f1856334-acdf-4d10-a4fa-eb84c378c589)

![image](https://github.com/gerpollo2000/dfp/assets/116986434/59d5b288-8f37-4bc7-a35f-c160dbb011a2)
